### PR TITLE
Fix some NaNs when window is small

### DIFF
--- a/charts_common_cf/lib/src/chart/cartesian/axis/draw_strategy/base_tick_draw_strategy.dart
+++ b/charts_common_cf/lib/src/chart/cartesian/axis/draw_strategy/base_tick_draw_strategy.dart
@@ -343,8 +343,16 @@ abstract class BaseTickDrawStrategy<D> implements TickDrawStrategy<D> {
       @required Rectangle<int> drawAreaBounds,
       @required bool isFirst,
       @required bool isLast}) {
-    final locationPx = tick.locationPx;
-    final labelOffsetPx = tick.labelOffsetPx ?? 0;
+    final locationPx = (tick.locationPx == null ||
+          tick.locationPx.isNaN ||
+          tick.locationPx.isInfinite)
+        ? 0
+        : tick.locationPx;
+    final labelOffsetPx = (tick.labelOffsetPx == null ||
+          tick.labelOffsetPx.isNaN ||
+          tick.labelOffsetPx.isInfinite)
+        ? 0
+        : tick.labelOffsetPx;
     final isRtl = chartContext.isRtl;
     final labelElements = _splitLabel(tick.textElement);
     final labelHeight = _getLabelHeight(labelElements);

--- a/charts_common_cf/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
+++ b/charts_common_cf/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
@@ -97,7 +97,7 @@ class NumericTickProvider extends BaseTickProvider<num> {
   /// It should prevent the scale from choosing fractional ticks.  For example,
   /// if you had a office head count, don't generate a tick for 1.5, instead
   /// jump to 2.
-  ///
+  //
   /// Note that the provider will choose whole number ticks in the axis units,
   /// not data units if a data to axis unit converter is set.
   bool dataIsInWholeNumbers = true;
@@ -413,7 +413,14 @@ class NumericTickProvider extends BaseTickProvider<num> {
     // If the range contains zero, ensure that zero is a tick.
     if (high >= 0 && low <= 0) {
       // determine the ratio of regions that are above the zero axis.
-      final posRegionRatio = (high > 0 ? min(1.0, high / (high - low)) : 0.0);
+      var posRegionRatio = (high > 0 ? min(1.0, high / (high - low)) : 0.0);
+      if (posRegionRatio.isNaN || posRegionRatio.isInfinite) {
+        if (posRegionRatio.isNegative) {
+          posRegionRatio = 1e100;
+        } else {
+          posRegionRatio = 1e100;
+        }
+      }
       var positiveRegionCount = (regionCount * posRegionRatio).ceil();
       var negativeRegionCount = regionCount - positiveRegionCount;
       // Ensure that negative regions are not excluded, unless there are no
@@ -541,7 +548,8 @@ class NumericTickProvider extends BaseTickProvider<num> {
   /// [number] of -63 returns -100
   /// [number] of 0.63 returns 1
   static double _getEnclosingPowerOfTen(num number) {
-    if (number == 0) {
+    if (number == 0 || number.isNaN || number.isInfinite) {
+    //if (number == 0) {
       return 1.0;
     }
 
@@ -551,7 +559,8 @@ class NumericTickProvider extends BaseTickProvider<num> {
 
   /// Returns the step numerically less than the number by step increments.
   static double _getStepLessThan(double number, double stepSize) {
-    if (number == 0.0 || stepSize == 0.0) {
+    if (number == 0.0 || number.isNaN || number.isInfinite || stepSize == 0.0) {
+    //if (number == 0.0 || stepSize == 0.0) {
       return 0.0;
     }
     return (stepSize > 0.0

--- a/charts_common_cf/test/chart/cartesian/axis/draw_strategy/tick_draw_strategy_test.dart
+++ b/charts_common_cf/test/chart/cartesian/axis/draw_strategy/tick_draw_strategy_test.dart
@@ -107,12 +107,14 @@ class MockChartCanvas extends Mock implements ChartCanvas {}
 
 /// Helper function to create [Tick] for testing.
 Tick<String> createTick(String value, double locationPx,
-    {double horizontalWidth,
+    {double labelOffsetPx,
+    double horizontalWidth,
     double verticalWidth,
     TextDirection textDirection}) {
   return Tick<String>(
       value: value,
       locationPx: locationPx,
+      labelOffsetPx: labelOffsetPx,
       textElement: FakeTextElement(
           value, textDirection, horizontalWidth, verticalWidth));
 }
@@ -526,6 +528,102 @@ void main() {
 
       final labelLine =
           verify(chartCanvas.drawText(captureAny, 20, 980, rotation: 0))
+              .captured
+              .single;
+      expect(labelLine.text, 'A');
+    });
+
+    test('Draw label with locationPx and labelOffset being null', () {
+      final chartCanvas = MockChartCanvas();
+      final axisBounds = Rectangle<int>(0, 0, 1000, 1000);
+
+      // A null locationPx defaults to 0
+      final Tick<String> tickNullLocationPx =
+        createTick('A', null, labelOffsetPx: null,
+            horizontalWidth: 10.0, verticalWidth: 15.0);
+
+      drawStrategy.drawLabel(
+        chartCanvas,
+        tickNullLocationPx,
+        orientation: AxisOrientation.top,
+        axisBounds: axisBounds,
+      );
+
+      // verify offsetX is 0
+      final labelLine =
+          verify(chartCanvas.drawText(captureAny, 0, 980, rotation: 0))
+              .captured
+              .single;
+      expect(labelLine.text, 'A');
+    });
+
+    test('Draw label with locationPx and labelOffset being nan', () {
+      final chartCanvas = MockChartCanvas();
+      final axisBounds = Rectangle<int>(0, 0, 1000, 1000);
+
+      // A null locationPx defaults to 0
+      final Tick<String> tickNullLocationPx =
+        createTick('A', double.nan, labelOffsetPx: double.nan,
+            horizontalWidth: 10.0, verticalWidth: 15.0);
+
+      drawStrategy.drawLabel(
+        chartCanvas,
+        tickNullLocationPx,
+        orientation: AxisOrientation.top,
+        axisBounds: axisBounds,
+      );
+
+      // verify offsetX is 0
+      final labelLine =
+          verify(chartCanvas.drawText(captureAny, 0, 980, rotation: 0))
+              .captured
+              .single;
+      expect(labelLine.text, 'A');
+    });
+
+    test('Draw label with locationPx and labelOffset being infinity', () {
+      final chartCanvas = MockChartCanvas();
+      final axisBounds = Rectangle<int>(0, 0, 1000, 1000);
+
+      // A null locationPx defaults to 0
+      final Tick<String> tickNullLocationPx =
+        createTick('A', double.infinity, labelOffsetPx: double.infinity,
+            horizontalWidth: 10.0, verticalWidth: 15.0);
+
+      drawStrategy.drawLabel(
+        chartCanvas,
+        tickNullLocationPx,
+        orientation: AxisOrientation.top,
+        axisBounds: axisBounds,
+      );
+
+      // verify offsetX is 0
+      final labelLine =
+          verify(chartCanvas.drawText(captureAny, 0, 980, rotation: 0))
+              .captured
+              .single;
+      expect(labelLine.text, 'A');
+    });
+
+    test('Draw label with locationPx and labelOffset being negativeInfinity', () {
+      final chartCanvas = MockChartCanvas();
+      final axisBounds = Rectangle<int>(0, 0, 1000, 1000);
+
+      // A null locationPx defaults to 0
+      final Tick<String> tickNullLocationPx =
+        createTick('A', double.negativeInfinity, labelOffsetPx: double.negativeInfinity,
+            horizontalWidth: 10.0, verticalWidth: 15.0);
+
+      drawStrategy.drawLabel(
+        chartCanvas,
+        tickNullLocationPx,
+        orientation: AxisOrientation.top,
+        axisBounds: axisBounds,
+      );
+
+      // verify offsetX is 0
+      final labelLine =
+          verify(chartCanvas.drawText(captureAny, 0, 980, rotation: 0))
               .captured
               .single;
       expect(labelLine.text, 'A');

--- a/charts_common_cf/test/chart/cartesian/axis/numeric_tick_provider_test.dart
+++ b/charts_common_cf/test/chart/cartesian/axis/numeric_tick_provider_test.dart
@@ -493,4 +493,441 @@ void main() {
     expect(ticks[4].value, equals(-22));
     expect(ticks[5].value, equals(-19));
   });
+
+  test('handles NaN to NaN', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = true
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+
+    when(scale.viewportDomain)
+        .thenReturn(NumericExtents(1.0, double.nan));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    //print('tickValues=$tickValues');
+    expect(tickValues, equals([1.0, 2.0, 3.0, 4.0, 5.0]));
+  });
+
+  test('handles 1.0 to NaN', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = true
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+
+    when(scale.viewportDomain)
+        .thenReturn(NumericExtents(1.0, double.nan));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    //print('ticks=$ticks');
+    expect(tickValues, equals([1.0, 2.0, 3.0, 4.0, 5.0]));
+  });
+
+  test('handles -NaN to -1', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = true
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+
+    when(scale.viewportDomain)
+        .thenReturn(NumericExtents(-double.nan, 1.0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): -Nan to -1 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues, equals([0.0, 1.0, 2.0, 3.0, 4.0]));
+  });
+
+
+  test('handles -100.0 to -1.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+
+    when(scale.viewportDomain)
+        .thenReturn(NumericExtents(-100.0, -1.0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    //print('tickValues=$tickValues');
+    expect(tickValues, equals([-100.0, -75.0, -50.0, -25.0, 0.0]));
+  });
+
+  test('handles -1e18 to 0.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(-1e18, 0.0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    expect(tickValues,
+        equals([
+              -1000000000000000000.0,
+              -750000000000000000.0,
+              -500000000000000000.0,
+              -250000000000000000.0,
+              0.0  ]));
+  });
+
+  test('handles -1e19 to 0.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(-1e19, 0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): -1e19 to 0.0 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([-10136092888451461000.0,
+              -7602069666338596000.0,
+              -5068046444225731000.0,
+              -2534023222112865300.0,
+              0.0]));
+  });
+
+  test('handles -1e300 to 0.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(-1e300, 0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): -1e300 to 0.0 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity]));
+  });
+
+  test('handles -maxFinite to 0.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(-double.maxFinite, 0.0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): -maxFinite to 0.0 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity]));
+  });
+
+  test('handles negativeInfinity to 0.0', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(double.negativeInfinity, 0.0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): negativeInfinity to 0.0 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity]));
+  });
+
+  test('handles 0.0 to 1e18', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(0.0, 1e18));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    expect(tickValues,
+        equals([0.0,
+              250000000000000000.0,
+              500000000000000000.0,
+              750000000000000000.0,
+              1000000000000000000.0]));
+  });
+
+  test('handles 0.0 to 1e19', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(-1e19, 0));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): 0.0 to 1e19 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([-10136092888451461000.0,
+              -7602069666338596000.0,
+              -5068046444225731000.0,
+              -2534023222112865300.0,
+              0.0]));
+  });
+
+  test('handles 0.0 to 1e300', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(0.0, 1e300));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): 0.0 to 1e300 looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([0.0, 1.0, 2.0, 3.0, 4.0]));
+  });
+
+
+  test('handles 0.0 to maxFinite', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(0.0, double.maxFinite));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): 0.0 to infinity, looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([0.0, 1.0, 2.0, 3.0, 4.0]));
+  });
+
+  test('handles 0.0 to infinity', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(0, double.infinity));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): 0.0 to infinity, looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([0.0, 1.0, 2.0, 3.0, 4.0]));
+  });
+
+  test('handles -infinity to infinity', () {
+    tickProvider
+      ..zeroBound = false
+      ..dataIsInWholeNumbers = false
+      ..setFixedTickCount(5);
+
+    final drawStrategy = FakeDrawStrategy(10, 10);
+    when(scale.viewportDomain).thenReturn(NumericExtents(double.negativeInfinity, double.infinity));
+    when(scale.rangeWidth).thenReturn(1000);
+
+    final ticks = tickProvider.getTicks(
+        context: context,
+        graphicsFactory: graphicsFactory,
+        scale: scale,
+        formatter: formatter,
+        formatterValueCache: <num, String>{},
+        tickDrawStrategy: drawStrategy,
+        orientation: null);
+
+    final tickValues = ticks.map((tick) => tick.value).toList();
+
+    // TODO(wink): -infinity to +infinity looks wrong?
+    //print('tickValues=$tickValues');
+    expect(tickValues,
+        equals([double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity,
+            double.negativeInfinity]));
+  });
 }


### PR DESCRIPTION
When grabing a corner and resizing the window such that it becomes
very small exceptions were thrown because of NaN's. I've changed
code where this occurred in my testing.

base_tick_draw_strategy.dart:
 - In BaseTickDrawStrategy.drawLabel a Tick is passed as a parameter
   and I saw tick.locationPx be NaN. Looking at Tick I decided that
   both locationPx and labelOffsetPx should be treated the same. So
   code was added that handles them being null, NaN or Infinte.

numeric_tick_provider.dart:
 - In NumericTickProvider._getEnclosingPowerOfTen the number parameter
   can be NaN. Changed so if number is also NaN or Infinite, 0 is
   returned.

 - In NumericTickProvider._getStepLessThan the number parameter
   can be NaN. Changed so if number is also NaN or infinite, 0.0 is
   returned.

Add some tests but in charts_common_cf/test/chart/cartesian/axis/numeric_tick_provider_test.dart
there are some tests that don't produce reasonable results. As one example
in 'handle -infinit to infinity' it all of the ticks are
double.negativeInfinity. I'll file a different bug for these.

Fixes: #12