### PR TITLE
Add custom template for use by auto-changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,34 +148,22 @@ whatever feature or bug fix you desire in `submodules/charts_cf/`. When it's
 working and tests are written, create a pull request from your fork to
 exafree/charts_cf.
 
-## Releasing **NOT WORKING**
+## Releasing
 
-This isn't working see issue #28.
+Release from [exafree/charts_cf](https://github.com/exafree/charts_cf) with
+the `release` branch checked out.
 
-You can release from a fork.
-
-1. Fork exafree/charts and clone, if you've not already done so.
-2. Add an upstream remote, if you've not already done so.
+1. Clone exafree/charts, if you've not already done so.
 ```
-$ git remote add upstream git@github.com:exafree/charts_cf
-$ git remote -v
-origin	git@github.com:winksaville/charts_cf (fetch)
-origin	git@github.com:winksaville/charts_cf (push)
-upstream	git@github.com:exafree/charts_cf (fetch)
-upstream	git@github.com:exafree/charts_cf (push)
+$ git clone git@github.com:exafree/charts_cf
 ```
-3. Sync with upstream and be sure your clone is `Already up to date`
+2. Checkout `release` branch, if you've not already done so.
 ```
 $ git checkout release
 Switched to branch 'release'
 Your branch is up to date with 'origin/release'.
-
-$ git pull upstream release
-From github.com:exafree/charts_cf
- * branch            release    -> FETCH_HEAD
-Already up to date.
 ```
-4. Get dependencies and run the tests
+3. Get dependencies and run the tests
 ```
 $ make get test
 Resolving dependencies...
@@ -187,37 +175,42 @@ Precompiled test:test.
 00:41 +417: All tests passed!
 00:02 +28: All tests passed!
 ```
-5. Create a release branch, use **next version** NOT 0.10.3+cf.
+4. Make the release commit, use the **next version** NOT 0.10.3+cf.
 This command updates version numbers in pubspec.yaml files,
-generates new changelog's, creates Release-x.y.z+cf branch,
-commits changes, creates tag, does a get, test and dry-run.
+generates new changelog's, commits changes, creates tag,
+does a get, test and dry-run.
 ```
 $ make rlease charts_ver=0.10.3+cf
 ```
-6. Push the branch and tags to your fork
+5. Do a `git status`, it should show no modified, untracked
+or changed files.
 ```
-git push origin Release-0.10.3+cf
-```
-7. On [exafree/charts_cf](https://github.com/exafree/charts_cf)
-create a Pull Request and then Squash and Merge.
-8. Checkout release, pull from upstream, push to origin/release so
-the release branch of your fork is upto date:
-```
-$ git checkout release
-$ git pull upstream release
-$ git push origin release
-```
-9. Final check before publishing the git-status should show no
-modified, untracked or changed files. You should also verify your
-perferred test application works!:
-```
-$ make get test dry-run
 $ git status
 ```
-10. if all is well publish:
+6. Verify your preferred test application works by changing the
+`charts_cf:` `path` field in `pubspec.yaml` to point to this local repo:
+```
+  #charts_flutter_cf: ^0.10.2
+  charts_flutter_cf:
+    path: ../path/to/exafree/charts_cf
+```
+7. Push the branch and tag, use the **next version** NOT 0.10.3+cf
+```
+git push origin release 0.10.3+cf
+```
+8. If all is well, publish:
 ```
 $ make publish
 ```
+9. Verify your preferred test application works with the
+newly published charts_cf. Change the `charts_cf:` in `pubspec.yaml`
+point to the **next version** NOT 0.10.3+cf:
+```
+  charts_flutter_cf: ^0.10.3+cf
+  #charts_flutter_cf:
+  #  path: ../path/to/exafree/charts_cf
+```
+10. Be Happy :)
 
 ## Makefile
 

--- a/charts_common_cf/.auto-changelog
+++ b/charts_common_cf/.auto-changelog
@@ -1,5 +1,5 @@
 {
-  "template": "keepachangelog",
+  "template": "../tools_cf/changelog.hbs",
   "unreleased": false,
   "commitLimit": false,
   "remote": "origin",

--- a/charts_flutter_cf/.auto-changelog
+++ b/charts_flutter_cf/.auto-changelog
@@ -1,5 +1,5 @@
 {
-  "template": "keepachangelog",
+  "template": "../tools_cf/changelog.hbs",
   "unreleased": false,
   "commitLimit": false,
   "remote": "origin",

--- a/tools_cf/changelog.hbs
+++ b/tools_cf/changelog.hbs
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project are documented by extracting
+information from git commits.  This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+{{#each releases}}
+  {{#if href}}
+    ## [{{title}}]({{href}}){{#if tag}} - {{isoDate}}{{/if}}
+  {{else}}
+    ## {{title}}{{#if tag}} - {{isoDate}}{{/if}}
+  {{/if}}
+
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+
+  {{#commit-list commits heading='### Direct Commits'}}
+    - {{#if breaking}}**Breaking change:** {{/if}}{{subject}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}
+  {{/commit-list}}
+
+  {{#if merges}}
+    ### Merged Commits
+
+    {{#each merges}}
+      - {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}{{#if href}} [`#{{id}}`]({{href}}){{/if}}
+    {{/each}}
+  {{/if}}
+
+  {{#if fixes}}
+    ### Issues Fixed
+
+    {{#each fixes}}
+      - {{#each fixes}}{{#if href}}[`#{{id}}`]({{href}}): {{/if}}{{/each}}{{#with commit}}{{#if breaking}}**Breaking change:** {{/if}}{{#if merge}}{{merge.message}} {{#if merge.href}}[`#{{merge.id}}`]({{merge.href}}){{/if}}{{else}}{{subject}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}{{/if}}{{/with}}
+    {{/each}}
+  {{/if}}
+
+{{/each}}

--- a/tools_cf/charts_common.original.CHANGELOG.md
+++ b/tools_cf/charts_common.original.CHANGELOG.md
@@ -1,7 +1,7 @@
 * Try again, forgot to add homepage to sed script for pubspec.
 * Tweak link in charts_flutter_cf/README.md to github.com/exafree/charts_cf
 
-# 0.10.1
+## 0.10.1
 * Second attempt at a Fork of google/charts with pachages renamed
   from charts_common and charts_flutter to charts_common_cf and
 harts_flutter_cf. Where "cf" is an acronym for "community fork".
@@ -10,25 +10,25 @@ harts_flutter_cf. Where "cf" is an acronym for "community fork".
 * In Makefile fixed a typo, leaving off the _cf in `cd charts_common_cf`
   in the publish_common target. And remove a debug `ls` in test_flutter target.
 
-# 0.10.0
+## 0.10.0
 * Fork of google/charts with pachages renamed from charts_common
   and charts_flutter to charts_common_cf and charts_flutter_cf.
   Where "cf" is an acronym for "community fork".
 
-# 0.9.0
+## 0.9.0
 * Internal bug fixes
 * Bump versions in Gemlock file due to security alerts
 
-# 0.8.1
+## 0.8.1
 * Update intl version.
 
-# 0.8.0
+## 0.8.0
 * Bug fixes from open source.
 
-# 0.7.0
+## 0.7.0
 * Added vertical bar label
 
-# 0.6.0
+## 0.6.0
 * Bars can now be rendered on line charts.
 * Negative measure values will now be rendered on bar charts as a separate stack from the positive
 values.
@@ -41,7 +41,7 @@ has been added to Series, and corresponding data to the datum. We could not use 
 these elements, because that color is already applied to the internal section of points on line
 charts (including highlighter behaviors).
 
-# 0.5.0
+## 0.5.0
 * SelectionModelConfig's listener parameter has been renamed to "changeListener". This is a breaking
 change. Please rename any existing uses of the "listener" parameter to "changeListener". This was
 named in order to add an additional listener "updateListener" that listens to any update requests,
@@ -51,14 +51,14 @@ getMeasureAxis({String axisId) so that getting the primary measure axis will not
 that does not match the secondary measure axis id. This affects users implementing custom behaviors
 using the existing method.
 
-# 0.4.0
+## 0.4.0
 * Declare compatibility with Dart 2.
 * BasicNumericTickFormatterSpec now takes in a callback instead of NumberFormat as the default constructor. Use named constructor withNumberFormat instead. This is a breaking change.
 * BarRendererConfig is no longer default of type String, please change current usage to BarRendererConfig<String>. This is a breaking change.
 * BarTargetLineRendererConfig is no longer default of type String, please change current usage to BarTargetLineRendererConfig<String>. This is a breaking change.
 
 
-# 0.3.0
+## 0.3.0
 * Simplified API by removing the requirement for specifying the datum type when creating a chart.
 For example, previously to construct a bar chart the syntax was 'new BarChart<MyDatumType>()'.
 The syntax is now cleaned up to be 'new BarChart()'. Please refer to the
@@ -68,11 +68,11 @@ The syntax is now cleaned up to be 'new BarChart()'. Please refer to the
 * Added support for rendering area skirts to line charts
 * Added support for configurable fill colors to bar charts
 
-# 0.2.0
+## 0.2.0
 
 * Update color palette. Please use MaterialPalette instead of QuantumPalette.
 * Dart2 fixes
 
-# 0.1.0
+## 0.1.0
 
 Initial release.

--- a/tools_cf/charts_flutter.original.CHANGELOG.md
+++ b/tools_cf/charts_flutter.original.CHANGELOG.md
@@ -1,7 +1,7 @@
 * Try again, forgot to add homepage to sed script for pubspec.
 * Tweak link in charts_flutter_cf/README.md to github.com/exafree/charts_cf
 
-# 0.10.1
+## 0.10.1
 * Second attempt at a Fork of google/charts with pachages renamed
   from charts_common and charts_flutter to charts_common_cf and
 harts_flutter_cf. Where "cf" is an acronym for "community fork".
@@ -10,25 +10,25 @@ harts_flutter_cf. Where "cf" is an acronym for "community fork".
 * In Makefile fixed a typo, leaving off the _cf in `cd charts_common_cf`
   in the publish_common target. And remove a debug `ls` in test_flutter target.
 
-# 0.10.0
+## 0.10.0
 * Fork of google/charts with pachages renamed from charts_common
   and charts_flutter to charts_common_cf and charts_flutter_cf.
   Where "cf" is an acronym for "community fork".
 
-# 0.9.0
+## 0.9.0
 * Internal bug fixes
 * Bump versions in Gemlock file due to security alerts
 
-# 0.8.1
+## 0.8.1
 * Update intl version.
 
-# 0.8.0
+## 0.8.0
 * Bug fixes from open source.
 
-# 0.7.0
+## 0.7.0
 * Added vertical bar label
 
-# 0.6.0
+## 0.6.0
 * Bars can now be rendered on line charts.
 * Negative measure values will now be rendered on bar charts as a separate stack from the positive
 values.
@@ -41,7 +41,7 @@ has been added to Series, and corresponding data to the datum. We could not use 
 these elements, because that color is already applied to the internal section of points on line
 charts (including highlighter behaviors).
 
-# 0.5.0
+## 0.5.0
 * SelectionModelConfig's listener parameter has been renamed to "changeListener". This is a breaking
 change. Please rename any existing uses of the "listener" parameter to "changeListener". This was
 named in order to add an additional listener "updateListener" that listens to any update requests,
@@ -51,7 +51,7 @@ getMeasureAxis({String axisId) so that getting the primary measure axis will not
 that does not match the secondary measure axis id. This affects users implementing custom behaviors
 using the existing method.
 
-# 0.4.0
+## 0.4.0
 * Fixed export file to export ChartsBehavior in the Flutter library instead of the one that resides
 in charts_common. The charts_common behavior should not be used except internally in the
 charts_flutter library. This is a breaking change if you are using charts_common behavior.
@@ -63,7 +63,7 @@ BarRendererConfig<String>. This is a breaking change.
 * BarTargetLineRendererConfig is no longer default of type String, please change current usage to
 BarTargetLineRendererConfig<String>. This is a breaking change.
 
-# 0.3.0
+## 0.3.0
 * Simplified API by removing the requirement for specifying the datum type when creating a chart.
 For example, previously to construct a bar chart the syntax was 'new BarChart<MyDatumType>()'.
 The syntax is now cleaned up to be 'new BarChart()'. Please refer to the
@@ -73,11 +73,11 @@ The syntax is now cleaned up to be 'new BarChart()'. Please refer to the
 * Added support for rendering area skirts to line charts
 * Added support for configurable fill colors to bar charts
 
-# 0.2.0
+## 0.2.0
 
 * Update color palette. Please use MaterialPalette instead of QuantumPalette.
 * Dart2 fixes
 
-# 0.1.0
+## 0.1.0
 
 Initial release.


### PR DESCRIPTION
Added tools_cf/changelog.hbs and modified .auto-changelog files to use
it.

The tools_cf/changlog.hbs is a modification of keepachangelog.hbs from:
 https://github.com/CookPete/auto-changelog/blob/0aff625cf4b8afc329ba5e60116283ec8f5a9239/templates/keepachangelog.hbs

I used the instructions [here](https://github.com/CookPete/auto-changelog#custom-templates)
to and the changes to keepachangelog.hbs were:

 - Moved `### Commits` up and renamee it `### Release Commits`
 - Adds issue id with href ':' followed by the commit.merge.message then
   commit.merge.id with commit.merge.href.

Also, update Makefile and README.md.

fixes #28